### PR TITLE
Fix deprecated messages

### DIFF
--- a/src/DependencyInjection/AwsExtension.php
+++ b/src/DependencyInjection/AwsExtension.php
@@ -50,9 +50,17 @@ class AwsExtension extends Extension
             class_exists($clientClass) ? $clientClass : AwsClient::class
         );
 
-        $serviceDefinition
-            ->setFactoryService('aws_sdk')
-            ->setFactoryMethod('create' . $name);
+        // Handle Symfony >= 2.6
+        if (method_exists($serviceDefinition, 'setFactory')) {
+            $serviceDefinition->setFactory([
+                new Reference('aws_sdk'),
+                'create' . $name,
+            ]);
+        } else {
+            $serviceDefinition
+                ->setFactoryService('aws_sdk')
+                ->setFactoryMethod('create' . $name);
+        }
 
         return $serviceDefinition;
     }


### PR DESCRIPTION
I know this was in a older release, but with going back to support 2.3 introduced over 200 deprecated messages in 2.7. Added a check for the newer method and use that one if there.
